### PR TITLE
OPS-986: Copy upstream helm chart and add memgraph exporter monitoring

### DIFF
--- a/charts/memgraph/Chart.yaml
+++ b/charts/memgraph/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/memgraph/Chart.yaml
+++ b/charts/memgraph/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/memgraph/templates/_helpers.tpl
+++ b/charts/memgraph/templates/_helpers.tpl
@@ -66,3 +66,38 @@ Default external url
 {{- define "memgraph.defaultHostUrl" -}}
 {{- print   (include "memgraph.fullname" .) "."  .Release.Namespace "." .Values.hostPostfix  -}}
 {{- end }}
+
+{{/*
+Memgraph Exporter name
+*/}}
+{{- define "memgraphExporter.name" -}}
+{{- printf "%s-exporter" (include "memgraph.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Memgraph Exporter fullname
+*/}}
+{{- define "memgraphExporter.fullname" -}}
+{{- printf "%s-exporter" (include "memgraph.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Memgraph Exporter labels
+*/}}
+{{- define "memgraphExporter.labels" -}}
+helm.sh/chart: {{ include "memgraph.chart" . }}
+{{ include "memgraphExporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics-exporter
+{{- end }}
+
+{{/*
+Memgraph Exporter selector labels
+*/}}
+{{- define "memgraphExporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "memgraphExporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: mg-exporter-config
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
 data:
   standalone_config.yaml: |
     exporter:
@@ -20,6 +22,7 @@ metadata:
   name: mg-exporter
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
     app: mg-exporter
 spec:
   replicas: 1
@@ -56,6 +59,7 @@ metadata:
   name: mg-exporter
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
     app: mg-exporter
 spec:
   selector:
@@ -73,6 +77,7 @@ metadata:
   name: mg-exporter
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
     release: {{ .Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
   selector:

--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mg-exporter-config
+  name: {{ include "memgraphExporter.fullname" . }}-config
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
-    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- include "memgraphExporter.labels" . | nindent 4 }}
 data:
   standalone_config.yaml: |
     exporter:
@@ -19,20 +19,19 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraphExporter.fullname" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
-    {{- include "memgraph.labels" . | nindent 4 }}
-    app: mg-exporter
+    {{- include "memgraphExporter.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mg-exporter
+      {{- include "memgraphExporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: mg-exporter
+        {{- include "memgraphExporter.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: exporter
@@ -51,19 +50,18 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: mg-exporter-config
+            name: {{ include "memgraphExporter.fullname" . }}-config
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraphExporter.fullname" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
-    {{- include "memgraph.labels" . | nindent 4 }}
-    app: mg-exporter
+    {{- include "memgraphExporter.labels" . | nindent 4 }}
 spec:
   selector:
-    app: mg-exporter
+    {{- include "memgraphExporter.selectorLabels" . | nindent 4 }}
   ports:
     - protocol: TCP
       name: tcp-metrics-port
@@ -74,15 +72,15 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraphExporter.fullname" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
-    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- include "memgraphExporter.labels" . | nindent 4 }}
     release: {{ .Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
   selector:
     matchLabels:
-      app: mg-exporter
+      {{- include "memgraphExporter.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: tcp-metrics-port  # must be the same as the service port name
       interval: {{ .Values.prometheus.serviceMonitor.interval }}

--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mg-exporter-config
+  namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
+data:
+  standalone_config.yaml: |
+    exporter:
+      port: {{ .Values.prometheus.memgraphExporter.port }}
+    memgraph:
+      endpoint_url: http://{{ include "memgraph.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+      port: 9091
+    general:
+      pull_frequency_seconds: {{ .Values.prometheus.memgraphExporter.pullFrequencySeconds }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mg-exporter
+  namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
+  labels:
+    app: mg-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mg-exporter
+  template:
+    metadata:
+      labels:
+        app: mg-exporter
+    spec:
+      containers:
+        - name: exporter
+          image: {{ .Values.prometheus.memgraphExporter.repository }}:{{ .Values.prometheus.memgraphExporter.tag }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/mg-exporter/standalone_config.yaml
+              subPath: standalone_config.yaml
+          ports:
+            - containerPort: {{ .Values.prometheus.memgraphExporter.port }}
+          env:
+            - name: DEPLOYMENT_TYPE
+              value: standalone
+            - name: CONFIG_FILE
+              value: /etc/mg-exporter/standalone_config.yaml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: mg-exporter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mg-exporter
+  namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
+  labels:
+    app: mg-exporter
+spec:
+  selector:
+    app: mg-exporter
+  ports:
+    - protocol: TCP
+      name: tcp-metrics-port
+      port: {{ .Values.prometheus.memgraphExporter.port }}
+      targetPort: {{ .Values.prometheus.memgraphExporter.port }}
+---
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mg-exporter
+  namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
+  labels:
+    release: {{ .Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
+spec:
+  selector:
+    matchLabels:
+      app: mg-exporter
+  endpoints:
+    - port: tcp-metrics-port  # must be the same as the service port name
+      interval: {{ .Values.prometheus.serviceMonitor.interval }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.prometheus.namespace | default .Release.Namespace }} # This refers to where our service exposing the exporter is located
+{{- end }}
+{{- end }}

--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -12,7 +12,7 @@ data:
       port: {{ .Values.prometheus.memgraphExporter.port }}
     memgraph:
       endpoint_url: http://{{ include "memgraph.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-      port: 9091
+      port: {{ .Values.service.httpPortMonitoring }}
     general:
       pull_frequency_seconds: {{ .Values.prometheus.memgraphExporter.pullFrequencySeconds }}
 ---

--- a/charts/memgraph/templates/namespace-netpol.yaml
+++ b/charts/memgraph/templates/namespace-netpol.yaml
@@ -22,4 +22,16 @@ spec:
       ports:
       - port: bolt
       - port: platform
+      {{- if and .Values.prometheus.enabled .Values.service.enableHttpMonitoring }}
+      - port: http
+      {{- end }}
+    {{- if .Values.prometheus.enabled }}
+    # Allow memgraph exporter to access memgraph HTTP monitoring port
+    - from:
+      - podSelector:
+          matchLabels:
+            {{- include "memgraphExporter.selectorLabels" . | nindent 12 }}
+      ports:
+      - port: http
+    {{- end }}
 {{- end }}

--- a/charts/memgraph/templates/namespace-netpol.yaml
+++ b/charts/memgraph/templates/namespace-netpol.yaml
@@ -35,3 +35,34 @@ spec:
       - port: http
     {{- end }}
 {{- end }}
+---
+{{- if and .Values.networkPolicies.create .Values.prometheus.enabled }}
+# Network policy for memgraph exporter - allow egress to memgraph
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "memgraphExporter.fullname" . }}
+  namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "memgraphExporter.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "memgraphExporter.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    # Allow exporter to reach memgraph HTTP monitoring port
+    - to:
+      - podSelector:
+          matchLabels:
+            {{- include "memgraph.selectorLabels" . | nindent 12 }}
+      {{- if ne (.Values.prometheus.namespace | default .Release.Namespace) .Release.Namespace }}
+      - namespaceSelector:
+          matchLabels:
+            name: {{ .Release.Namespace }}
+      {{- end }}
+      ports:
+      - port: {{ .Values.service.httpPortMonitoring }}
+        protocol: TCP
+{{- end }}

--- a/charts/memgraph/templates/service.yaml
+++ b/charts/memgraph/templates/service.yaml
@@ -4,13 +4,28 @@ metadata:
   name: {{ include "memgraph.fullname" . }}
   labels:
     {{- include "memgraph.labels" . | nindent 4 }}
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 7687
-      targetPort: bolt
+    {{- if .Values.service.enableBolt }}
+    - port: {{ .Values.service.boltPort }}
+      targetPort: {{ .Values.service.boltPort }}
       protocol: TCP
-      name: bolt
+      name: tcp-bolt-port
+    {{- end }}
+    {{- if .Values.service.enableHttpMonitoring }}
+    - port: {{ .Values.service.httpPortMonitoring }}
+      targetPort: {{ .Values.service.httpPortMonitoring }}
+      protocol: TCP
+      name: http-monitoring-port
+    {{- end }}
     {{- if .Values.platform.enabled }}
     - port: 3000
       targetPort: platform

--- a/charts/memgraph/templates/service.yaml
+++ b/charts/memgraph/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   ports:
     {{- if .Values.service.enableBolt }}
     - port: {{ .Values.service.boltPort }}
-      targetPort: {{ .Values.service.boltPort }}
+      targetPort: bolt
       protocol: TCP
       name: tcp-bolt-port
     {{- end }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -110,6 +110,11 @@ spec:
             - name: bolt
               containerPort: 7687
               protocol: TCP
+            {{- if .Values.service.enableHttpMonitoring }}
+            - name: http
+              containerPort: {{ .Values.service.httpPortMonitoring }}
+              protocol: TCP
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: 7687

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -141,7 +141,6 @@ memgraphConfig:
   - "--schema-info-enabled=true"
   - "--storage-automatic-label-index-creation-enabled=true"
   # HTTP metrics for Prometheus monitoring
-  - "--metrics-enabled=true"
   - "--metrics-address=0.0.0.0"
   - "--metrics-port=9091"
   - "--storage-automatic-edge-type-index-creation-enabled=true"

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -108,7 +108,7 @@ service:
   enableBolt: true
   boltPort: 7687
   # HTTP Monitoring (required for Prometheus exporter)
-  enableHttpMonitoring: false
+  enableHttpMonitoring: true
   httpPortMonitoring: 9091
   annotations: {}
   labels: {}

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -104,6 +104,14 @@ securityContext:
 
 service:
   type: ClusterIP
+  # Bolt Protocol
+  enableBolt: true
+  boltPort: 7687
+  # HTTP Monitoring (required for Prometheus exporter)
+  enableHttpMonitoring: false
+  httpPortMonitoring: 9091
+  annotations: {}
+  labels: {}
 
 hostPostfix: k8s.dev.linkurious.net
 ingressRoute:
@@ -132,6 +140,10 @@ memgraphConfig:
   # for efficient schema sampling
   - "--schema-info-enabled=true"
   - "--storage-automatic-label-index-creation-enabled=true"
+  # HTTP metrics for Prometheus monitoring
+  - "--metrics-enabled=true"
+  - "--metrics-address=0.0.0.0"
+  - "--metrics-port=9091"
   - "--storage-automatic-edge-type-index-creation-enabled=true"
   # for efficiently loading edges by ID
   - "--storage-enable-edges-metadata=true"
@@ -168,3 +180,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Prometheus monitoring configuration
+prometheus:
+  enabled: true
+  namespace: null # Namespace where K8s resources from mg-exporter.yaml will be installed. If null, uses Release.Namespace
+  memgraphExporter:
+    port: 9115
+    pullFrequencySeconds: 5
+    repository: memgraph/prometheus-exporter
+    tag: 0.2.1
+  serviceMonitor:
+    enabled: true
+    kubePrometheusStackReleaseName: kube-prometheus-stack
+    interval: 15s
+
+# Note: When prometheus.enabled is true, you should also set:
+# service.enableHttpMonitoring: true

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -184,7 +184,7 @@ affinity: {}
 # Prometheus monitoring configuration
 prometheus:
   enabled: true
-  namespace: null # Namespace where K8s resources from mg-exporter.yaml will be installed. If null, uses Release.Namespace
+  namespace:  # Namespace where K8s resources from mg-exporter.yaml will be installed. If null, uses Release.Namespace
   memgraphExporter:
     port: 9115
     pullFrequencySeconds: 5


### PR DESCRIPTION
See https://grafana.monitoring.k8s.preprod.linkurious.net/explore?schemaVersion=1&panes=%7B%22dzd%22:%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22disk_usage%7Bnamespace%3D%5C%22preview%5C%22%7D%22,%22range%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D,%22compact%22:false%7D%7D&orgId=1 for proof it works :)